### PR TITLE
Change up how we marshal events and unmarshal them

### DIFF
--- a/events/event_test.go
+++ b/events/event_test.go
@@ -1,6 +1,7 @@
 package events_test
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -44,9 +45,14 @@ func TestNewPurchase(t *testing.T) {
 		t.Errorf("Expecting event id to start with evt_, got %s", ev.ID)
 	}
 
+	var purchaseData data.Purchase
+	if err := json.Unmarshal(ev.Data, &purchaseData); err != nil {
+		t.Errorf("Unable to unmarshall the purchase data: %s", err.Error())
+	}
+
 	// Checking if we can unmarshal the event back to the original data
-	if ev.Data.(data.Purchase).Type != events.PurchaseDataType {
-		t.Errorf("Expecting event data type %s, got %s", events.PurchaseDataType, ev.Data.(data.Purchase).Type)
+	if purchaseData.Type != events.PurchaseDataType {
+		t.Errorf("Expecting event data type %s, got %s", events.PurchaseDataType, purchaseData.Type)
 	}
 }
 
@@ -93,9 +99,14 @@ func TestNewSubscription(t *testing.T) {
 		t.Errorf("Expecting event id to start with evt_, got %s", ev.ID)
 	}
 
+	var subscriptionData data.Subscription
+	if err := json.Unmarshal(ev.Data, &subscriptionData); err != nil {
+		t.Errorf("Unable to unmarshall the subscription data: %s", err.Error())
+	}
+
 	// Checking if we can unmarshal the event back to the original data
-	if ev.Data.(data.Subscription).Type != events.SubscriptionDataType {
-		t.Errorf("Expecting event data type %s, got %s", events.SubscriptionDataType, ev.Data.(data.Subscription).Type)
+	if subscriptionData.Type != events.SubscriptionDataType {
+		t.Errorf("Expecting event data type %s, got %s", events.SubscriptionDataType, subscriptionData.Type)
 	}
 }
 

--- a/events/objectTypes.go
+++ b/events/objectTypes.go
@@ -1,0 +1,14 @@
+package events
+
+// EventObjectType holds the event type we are working.
+type EventObjectType string
+
+const (
+	// SubscriptionDataType describes the type of the data we are holding.
+	// It allow us easily map data from the database to a struct
+	SubscriptionDataType EventObjectType = "subscription"
+
+	// PurchaseDataType describes the type of the data we are holding.
+	// It allow us easily map data from the database to a struct
+	PurchaseDataType EventObjectType = "purchase"
+)

--- a/events/types.go
+++ b/events/types.go
@@ -1,0 +1,26 @@
+package events
+
+// EventType is a unique key defined by event
+type EventType string
+
+const (
+	// AppSubscribedEventType defines the string constant name for the event that happens when
+	// a user subscribes to a plan
+	AppSubscribedEventType EventType = "app.subscription.created"
+
+	// AppSubscriptionCancelledEventType defines the string constant name for the event that happens when
+	// a user cancels a subscription
+	AppSubscriptionCancelledEventType EventType = "app.subscription.cancelled"
+
+	// AppSubscriptionModifiedEventType defines the string constant name for the event that happens when
+	// a subscription is modified
+	AppSubscriptionModifiedEventType EventType = "app.subscription.modified"
+
+	// AppPurchasedEventType indicates which type the struct is. Could make it easier for us data map this event from the database
+	AppPurchasedEventType EventType = "app.purchase.created"
+)
+
+func (et EventType) Valid() bool {
+	return et == AppSubscribedEventType || et == AppPurchasedEventType ||
+		et == AppSubscriptionCancelledEventType || et == AppSubscriptionModifiedEventType
+}


### PR DESCRIPTION
# What? :boat:
- Uses the `json.RawMessage` on the Event data property

# Why? :thinking:
- Better experience for unmarshalling of the data

# Checklist :ballot_box_with_check:
- [x] **I have added added tests for PR or I have justified why this PR doesn't need tests.**
- [ ] **Swager definition added (if new route or route is adjusted)**
