### PR TITLE
Add the account id to the workspace information

### DIFF
--- a/events/event.go
+++ b/events/event.go
@@ -35,9 +35,10 @@ type BundleInfo struct {
 
 // Workspace defines the workspace where the event was triggered
 type Workspace struct {
-	ID       string `bson:"id" json:"id"`
-	NickName string `bson:"nickName" json:"nickName"`
-	Address  string `bson:"address" json:"address"`
+	ID        string `bson:"id" json:"id"`
+	AccountID string `bson:"accountId" json:"accountId"`
+	NickName  string `bson:"nickName" json:"nickName"`
+	Address   string `bson:"address" json:"address"`
 }
 
 //#region APIVersion

--- a/events/event_test.go
+++ b/events/event_test.go
@@ -19,9 +19,10 @@ func TestNewPurchase(t *testing.T) {
 	}
 
 	w := events.Workspace{
-		ID:       "workspace-id",
-		NickName: "my test workspace",
-		Address:  "https://mytestworkspace.example.com",
+		ID:        "workspace-id",
+		AccountID: "account-id",
+		NickName:  "my test workspace",
+		Address:   "https://mytestworkspace.example.com",
 	}
 
 	d := data.Purchase{
@@ -65,9 +66,10 @@ func TestNewSubscription(t *testing.T) {
 	}
 
 	w := events.Workspace{
-		ID:       "workspace-id",
-		NickName: "my test workspace",
-		Address:  "https://mytestworkspace.example.com",
+		ID:        "workspace-id",
+		AccountID: "account-id",
+		NickName:  "my test workspace",
+		Address:   "https://mytestworkspace.example.com",
 	}
 
 	d := data.Subscription{


### PR DESCRIPTION
# What? :boat:
- Adds the account id to the workspace information

# Why? :thinking:
- Workspaces are child objects of the accounts. One can not have a workspace without an account and we expose this information in the workspace object.

# Checklist :ballot_box_with_check:
- [x] **I have added added tests for PR or I have justified why this PR doesn't need tests.**
- [ ] **Swager definition added (if new route or route is adjusted)**