### PR TITLE
Add a new event type for subscriptions migrated to a bundle

### DIFF
--- a/data/subscription.go
+++ b/data/subscription.go
@@ -57,6 +57,9 @@ type Subscription struct {
 
 	// FromBundleID indicates which bundle id triggered this subscription event for the app
 	FromBundleID string `bson:"fromBundleId,omitempty" json:"fromBundleId,omitempty"`
+
+	// MigratedToBundle indicates if the subscription was migrated from a single app subscription to a bundle subscription
+	MigratedToBundle bool `bson:"migratedToBundle,omitempty" json:"migratedToBundle,omitempty"`
 }
 
 //#region PricingRecurrence

--- a/events/event.go
+++ b/events/event.go
@@ -48,7 +48,7 @@ type APIVersion string
 
 const (
 	// CurrentAPIVersion specify the lastest API version
-	CurrentAPIVersion APIVersion = "0.1.0"
+	CurrentAPIVersion APIVersion = "1.1.0"
 )
 
 //#endregion APIVersion

--- a/events/event.go
+++ b/events/event.go
@@ -48,7 +48,7 @@ type APIVersion string
 
 const (
 	// CurrentAPIVersion specify the lastest API version
-	CurrentAPIVersion APIVersion = "1.0.0"
+	CurrentAPIVersion APIVersion = "0.1.0"
 )
 
 //#endregion APIVersion

--- a/events/types.go
+++ b/events/types.go
@@ -16,11 +16,11 @@ const (
 	// a subscription is modified
 	AppSubscriptionModifiedEventType EventType = "app.subscription.modified"
 
+	// AppSubscriptionMigratedEventType defines the event related to when a subscription is migrate to use the bundle
+	AppSubscriptionMigratedEventType EventType = "app.subscription.migrated"
+
 	// AppPurchasedEventType indicates which type the struct is. Could make it easier for us data map this event from the database
 	AppPurchasedEventType EventType = "app.purchase.created"
-
-	// AppBundleSubscriptionMigratedEventType defines the event related to when a subscription is migrate to use the bundle
-	AppBundleSubscriptionMigratedEventType EventType = "app.subscription.bundle.migrated"
 )
 
 func (et EventType) Valid() bool {

--- a/events/types.go
+++ b/events/types.go
@@ -18,6 +18,9 @@ const (
 
 	// AppPurchasedEventType indicates which type the struct is. Could make it easier for us data map this event from the database
 	AppPurchasedEventType EventType = "app.purchase.created"
+
+	// AppBundleSubscriptionMigratedEventType defines the event related to when a subscription is migrate to use the bundle
+	AppBundleSubscriptionMigratedEventType EventType = "app.subscription.bundle.migrated"
 )
 
 func (et EventType) Valid() bool {

--- a/events/types.go
+++ b/events/types.go
@@ -24,6 +24,9 @@ const (
 )
 
 func (et EventType) Valid() bool {
-	return et == AppSubscribedEventType || et == AppPurchasedEventType ||
-		et == AppSubscriptionCancelledEventType || et == AppSubscriptionModifiedEventType
+	return et == AppSubscribedEventType ||
+		et == AppPurchasedEventType ||
+		et == AppSubscriptionCancelledEventType ||
+		et == AppSubscriptionModifiedEventType ||
+		et == AppSubscriptionMigratedEventType
 }


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->

We are introducing a new event type called `app.subscription.bundle.migrated` that happens when an app subscription is migrated to a bundle. We are also introducing a new field called MigratedToBundle that holds the information if the actual subscription was either migrated or not.


# Why? :thinking:
<!--Additional explanation if needed-->

# Checklist :ballot_box_with_check:
- [x] **I have added added tests for PR or I have justified why this PR doesn't need tests.**
- [x] **Swager definition added (if new route or route is adjusted)**

# Links :earth_americas:
[Task](https://app.clickup.com/t/2hz8f3h)


# PS :video_game:
<!-- Put anything else here you want us to know -->
