### PR TITLE
Add a github workflow to automatically generate a new tag

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -14,3 +14,4 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         WITH_V: true
+        INITIAL_VERSION: 1.1.0

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,16 @@
+name: Bump version
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Bump version and push tag
+      uses: anothrNick/github-tag-action@1.36.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        WITH_V: true


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
This is a suggestion to automatically create a new tag whenever we push something to main. The tag is based on semantic versioning and will look into the commit message to know if it is a major, minor, or patch.

As we squash commits before merging, we end up with just one commit. The auto-tag will use this commit to know the next version.

For example, our project is at version 1.0.0. A new Pull Request will be merged.
If you add #major to the commit, the next version tag will be 2.0.0
if you add #minor to the commit, the next version tag will be 1.1.0
if you add #patch to the commit,  the next version tag will be 1.0.1

# Why? :thinking:
<!--Additional explanation if needed-->

# Checklist :ballot_box_with_check:
- [x] **I have added added tests for PR or I have justified why this PR doesn't need tests.**
- [x] **Swager definition added (if new route or route is adjusted)**

# Links :earth_americas:
<!--
[Task](https://app.clickup.com/t/:task_id:)
-->

# PS :video_game:
<!-- Put anything else here you want us to know -->
