### PR TITLE
Add new events to cover bundle restrictions

### DIFF
--- a/data/bundle.go
+++ b/data/bundle.go
@@ -7,6 +7,9 @@ import "github.com/RocketChat/marketplace-go/events"
 type BundleAction struct {
 	Type events.EventObjectType `bson:"objectType" json:"objectType"`
 
+	// Bundle defines the bundle that is affected by the action
 	Bundle events.App `bson:"bundle" json:"bundle"`
-	App    events.App `bson:"app" json:"app"`
+
+	// App defines the app that is affected by the action
+	App events.App `bson:"app" json:"app"`
 }

--- a/data/bundle.go
+++ b/data/bundle.go
@@ -1,0 +1,12 @@
+package data
+
+import "github.com/RocketChat/marketplace-go/events"
+
+// BundleAction defines the data we will send when something happens to a bundle.
+// Right now, we have: add/remove an app to bundle, add/remove restriction to an app in a bundle
+type BundleAction struct {
+	Type events.EventObjectType `bson:"objectType" json:"objectType"`
+
+	Bundle events.App `bson:"bundle" json:"bundle"`
+	App    events.App `bson:"app" json:"app"`
+}

--- a/events/event.go
+++ b/events/event.go
@@ -24,6 +24,9 @@ type App struct {
 
 	BundledAppIDs []string     `bson:"bundledAppIds,omitempty" json:"bundledAppIds,omitempty"`
 	BundledIn     []BundleInfo `bson:"bundledIn,omitempty" json:"bundledIn,omitempty"` // BundledIn only includes id and name
+
+	RestrictToBundle     bool   `bson:"restrictToBundle" json:"restrictToBundle"`
+	RestrictedToBundleID string `bson:"restrictedToBundleId" json:"restrictedToBundleId"`
 }
 
 // BundleInfo defines information about a bundle when the app is included in a bundle.
@@ -48,7 +51,7 @@ type APIVersion string
 
 const (
 	// CurrentAPIVersion specify the lastest API version
-	CurrentAPIVersion APIVersion = "1.1.0"
+	CurrentAPIVersion APIVersion = "1.2.0"
 )
 
 //#endregion APIVersion

--- a/events/event.go
+++ b/events/event.go
@@ -26,7 +26,7 @@ type App struct {
 	BundledIn     []BundleInfo `bson:"bundledIn,omitempty" json:"bundledIn,omitempty"` // BundledIn only includes id and name
 
 	RestrictToBundle     bool   `bson:"restrictToBundle" json:"restrictToBundle"`
-	RestrictedToBundleID string `bson:"restrictedToBundleId" json:"restrictedToBundleId"`
+	RestrictedToBundleID string `bson:"restrictedToBundleId,omitempty" json:"restrictedToBundleId,omitempty"`
 }
 
 // BundleInfo defines information about a bundle when the app is included in a bundle.

--- a/events/objectTypes.go
+++ b/events/objectTypes.go
@@ -11,4 +11,8 @@ const (
 	// PurchaseDataType describes the type of the data we are holding.
 	// It allow us easily map data from the database to a struct
 	PurchaseDataType EventObjectType = "purchase"
+
+	// BundleActionDataType describes the type of the data we are holding.
+	// It allow us easily map data from the database to a struct
+	BundleActionDataType EventObjectType = "bundleAction"
 )

--- a/events/types.go
+++ b/events/types.go
@@ -28,9 +28,22 @@ const (
 
 	// AppBundleUnrestrictedEventType happens when an app is unrestricted to a bundle
 	AppBundleUnrestrictedEventType EventType = "app.bundle.unrestricted"
+
+	// BundleRestrictionAddedEventType happens when a bundle is restricted to an app
+	BundleRestrictionAddedEventType EventType = "bundle.restriction.added"
+
+	// BundleRestrictionRemovedEventType happens when a bundle is unrestricted to an app
+	BundleRestrictionRemovedEventType EventType = "bundle.restriction.removed"
 )
 
+// Valid events will look for all available events type we have. If the event is one of them, than it's valid
 func (et EventType) Valid() bool {
+	return et.ValidAppEvent() || et.ValidBundleEvent()
+}
+
+// ValidAppEvent will only look for app related events, so if you want to check if it's an app related event
+// you can use this method
+func (et EventType) ValidAppEvent() bool {
 	return et == AppSubscribedEventType ||
 		et == AppPurchasedEventType ||
 		et == AppSubscriptionCancelledEventType ||
@@ -38,4 +51,9 @@ func (et EventType) Valid() bool {
 		et == AppSubscriptionMigratedEventType ||
 		et == AppBundleRestrictedEventType ||
 		et == AppBundleUnrestrictedEventType
+}
+
+// ValidBundleEvent will only look for bundle related events, so if you want to check if it's a bundle related event
+func (et EventType) ValidBundleEvent() bool {
+	return et == BundleRestrictionAddedEventType || et == BundleRestrictionRemovedEventType
 }

--- a/events/types.go
+++ b/events/types.go
@@ -29,11 +29,11 @@ const (
 	// AppBundleUnrestrictedEventType happens when an app is unrestricted to a bundle
 	AppBundleUnrestrictedEventType EventType = "app.bundle.unrestricted"
 
-	// BundleRestrictionAddedEventType happens when a bundle is restricted to an app
-	BundleRestrictionAddedEventType EventType = "bundle.restriction.added"
+	// BundleAppAddedEventType happens when a bundle is restricted to an app
+	BundleAppAddedEventType EventType = "bundle.app.added"
 
-	// BundleRestrictionRemovedEventType happens when a bundle is unrestricted to an app
-	BundleRestrictionRemovedEventType EventType = "bundle.restriction.removed"
+	// BundleAppRemovedEventType happens when a bundle is unrestricted to an app
+	BundleAppRemovedEventType EventType = "bundle.app.removed"
 )
 
 // Valid events will look for all available events type we have. If the event is one of them, than it's valid
@@ -55,5 +55,5 @@ func (et EventType) ValidAppEvent() bool {
 
 // ValidBundleEvent will only look for bundle related events, so if you want to check if it's a bundle related event
 func (et EventType) ValidBundleEvent() bool {
-	return et == BundleRestrictionAddedEventType || et == BundleRestrictionRemovedEventType
+	return et == BundleAppAddedEventType || et == BundleAppRemovedEventType
 }

--- a/events/types.go
+++ b/events/types.go
@@ -21,6 +21,13 @@ const (
 
 	// AppPurchasedEventType indicates which type the struct is. Could make it easier for us data map this event from the database
 	AppPurchasedEventType EventType = "app.purchase.created"
+
+	// AppBundleRestrictedEventType happens when an app is restricted to a bundle
+	// When an app is restricted to a bundle, it means the app can only be used if you subscribe the bundle
+	AppBundleRestrictedEventType EventType = "app.bundle.restricted"
+
+	// AppBundleUnrestrictedEventType happens when an app is unrestricted to a bundle
+	AppBundleUnrestrictedEventType EventType = "app.bundle.unrestricted"
 )
 
 func (et EventType) Valid() bool {
@@ -28,5 +35,7 @@ func (et EventType) Valid() bool {
 		et == AppPurchasedEventType ||
 		et == AppSubscriptionCancelledEventType ||
 		et == AppSubscriptionModifiedEventType ||
-		et == AppSubscriptionMigratedEventType
+		et == AppSubscriptionMigratedEventType ||
+		et == AppBundleRestrictedEventType ||
+		et == AppBundleUnrestrictedEventType
 }


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
This PR adds 4 new events related to restricting an app to a bundle. 

I'm introducing a new data type called bundle actions, which holds a bundle and an app. Both of them are affected by the action, which you can infer by the action type.

**Example**
* App added to a bundle
   - The bundle field represents the bundle to which the app was added
   - The app field represents the app which was added to the bundle

# Why? :thinking:
<!--Additional explanation if needed-->

# Checklist :ballot_box_with_check:
- [x] **I have added added tests for PR or I have justified why this PR doesn't need tests.**
- [x] **Swager definition added (if new route or route is adjusted)**

# Links :earth_americas:
<!--
[Task](https://app.clickup.com/t/:task_id:)
-->

# PS :video_game:
<!-- Put anything else here you want us to know -->
