### PR TITLE
Adds a data point for if the purchase or subscription is self managed

### DIFF
--- a/data/purchase.go
+++ b/data/purchase.go
@@ -20,6 +20,9 @@ type Purchase struct {
 	// BoughtAt defines when the app was purchased
 	BoughtAt time.Time `bson:"boughtAt" json:"boughtAt"`
 
+	// IsSelfManaged tells us whether the purchase is managed by the user or externally managed
+	IsSelfManaged bool `bson:"isSelfManaged" json:"isSelfManaged"`
+
 	// IsBundle tells us whether the purchase is a bundle
 	IsBundle bool `bson:"isBundle" json:"isBundle"`
 

--- a/data/subscription.go
+++ b/data/subscription.go
@@ -47,7 +47,11 @@ type Subscription struct {
 	// PeriodEnd defines when the subscription will end
 	PeriodEnd *time.Time `bson:"periodEnd,omitempty" json:"periodEnd,omitempty"`
 
+	// TerminationDate is the date which the subscription has been terminated
 	TerminationDate *time.Time `bson:"terminationDate,omitempty" json:"terminationDate,omitempty"`
+
+	// IsSelfManaged tells us whether the subscription is managed by the user or externally managed
+	IsSelfManaged bool `bson:"isSelfManaged" json:"isSelfManaged"`
 
 	// IsBundle tells us whether the subscription is a bundle
 	IsBundle bool `bson:"isBundle" json:"isBundle"`

--- a/events/event.go
+++ b/events/event.go
@@ -48,7 +48,7 @@ type APIVersion string
 
 const (
 	// CurrentAPIVersion specify the lastest API version
-	CurrentAPIVersion APIVersion = "1.1.0"
+	CurrentAPIVersion APIVersion = "1.2.0"
 )
 
 //#endregion APIVersion


### PR DESCRIPTION
# What? :boat:
- Adds a flag for purchases and subscriptions on whether it is self managed or not

# Why? :thinking:
- Purchase records and subscriptions can be externally managed so we need to expose that property