### PR TITLE
chore: pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/golang-test.yml
+++ b/.github/workflows/golang-test.yml
@@ -23,12 +23,12 @@ jobs:
 
     steps:
       - name: Install go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2.2.0
         with:
           go-version: ${{ matrix.go-version }}
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
       - name: Test
         run: go test ./...

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,10 +14,10 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018 # v2.5.2
         with:
           version: latest
           skip-build-cache: true


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
This PR replaces mutable tag references with immutable commit SHA pins for all third-party GitHub Actions, as part of a supply chain security hardening effort.

Each workflow file now references the exact commit SHA of the desired action version instead of a floating tag. This guarantees that the same code is always executed regardless of whether the version tag is moved or the action's repository is modified after pinning.


# Why? :thinking:
<!--Additional explanation if needed-->

# Checklist :ballot_box_with_check:
- [ ] **I have added added tests for PR or I have justified why this PR doesn't need tests.**
- [ ] **Swager definition added (if new route or route is adjusted)**

# Links :earth_americas:
<!--
[Task](https://app.clickup.com/t/:task_id:)

-->
[SB-958](https://rocketchat.atlassian.net/browse/SB-958)
# PS :video_game:
<!-- Put anything else here you want us to know -->


[SB-958]: https://rocketchat.atlassian.net/browse/SB-958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ