### PR TITLE
chore: apply least privilege permissions to github actions

### DIFF
--- a/.github/workflows/golang-test.yml
+++ b/.github/workflows/golang-test.yml
@@ -9,12 +9,12 @@ on:
       - main
       - develop
 
-permissions:
-  contents: read
-  pull-requests: read
+permissions: {}
 
 jobs:
   test:
+    permissions:
+      contents: read
     strategy:
       matrix:
         go-version: [1.18.x]

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -6,13 +6,14 @@ on:
     branches:
       - develop
   pull_request:
-permissions:
-  contents: read
-  pull-requests: read
+permissions: {}
+
 jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
 


### PR DESCRIPTION
# What? :boat:
<!--
- Added x;
- Updated y;
- Removed z.
-->
This PR applies the principle of least privilege to `GITHUB_TOKEN` permissions across all GitHub Actions workflows by setting `permissions: {}` globally and explicitly re-granting only the minimum permissions required per job, as part of a supply chain security hardening effort.

Workflows relied on GitHub’s default token scopes, which may grant more access than most jobs actually need. Scoping permissions at the job level reduces the attack surface in the event that a GitHub Action, third-party dependency, or CI component is compromised, helping mitigate the impact of potential supply chain attacks and limiting unnecessary repository access.

This change only affects the permissions granted to the workflow `GITHUB_TOKEN`. Operations authenticated using explicitly configured Personal Access Tokens (PATs) continue to have the scopes assigned to those tokens and are not affected by workflow permissions settings.

## Issue(s)
[SB-975](https://rocketchat.atlassian.net/browse/SB-975)
<!-- Link the issues being closed by or related to this PR. For example, you can use Closes #594 if this PR closes issue number 594 -->

# Why? :thinking:
<!--Additional explanation if needed-->

# Checklist :ballot_box_with_check:
- [ ] **I have added added tests for PR or I have justified why this PR doesn't need tests.**
- [ ] **Swager definition added (if new route or route is adjusted)**

# Links :earth_americas:
<!--
[Task](https://app.clickup.com/t/:task_id:)
-->

# PS :video_game:
<!-- Put anything else here you want us to know -->


[SB-975]: https://rocketchat.atlassian.net/browse/SB-975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ